### PR TITLE
Added: debian distribution in all tasks, examples (#9)

### DIFF
--- a/examples/sip3-backend.yml
+++ b/examples/sip3-backend.yml
@@ -1,0 +1,41 @@
+all:
+  hosts:
+    backend:
+      ansible_host: 192.168.215.15
+  vars:
+    ansible_user: ansible
+    ansible_port: 22
+    ansible_become: true
+
+    platform: debian
+    edition: ce
+    version: 2020.2.1
+
+    features:
+      - call
+      - register
+      - rtcp
+
+    mongodb:
+      version: 4.4
+      address: 127.0.0.1
+      port: 27017
+      path: /var/lib/mongodb
+      db: sip3
+
+    influxdb:
+      address: 127.0.0.1
+      port: 8086
+      path: /var/lib/influxdb
+      db: sip3
+
+    grafana:
+      datasources:
+        database: sip3
+
+    salto:
+      server:
+        uri: udp://0.0.0.0:15060
+      management:
+        uri: udp://0.0.0.0:15090
+

--- a/examples/sip3-captain.yml
+++ b/examples/sip3-captain.yml
@@ -1,0 +1,29 @@
+all:
+  hosts:
+    captain:
+      ansible_host: 192.168.215.16
+  vars:
+    ansible_user: ansible
+    ansible_port: 22
+    ansible_become: true
+
+    platform: debian
+    edition: ce
+    version: 2020.2.1
+
+    features:
+      - call
+      - register
+      - rtcp
+
+    captain:
+      pcap:
+        dev: eth0
+        bpf_filter: udp
+      sender:
+        uri: udp://192.168.215.15:15060
+      management:
+        uri: udp://192.168.215.15:15090
+      metrics:
+        logging:
+          step: 5000

--- a/examples/sip3-grafana.yml
+++ b/examples/sip3-grafana.yml
@@ -1,0 +1,21 @@
+all:
+  hosts:
+    grafana:
+      ansible_host: 192.168.215.15
+  vars:
+    ansible_user: ansible
+    ansible_port: 22
+    ansible_become: true
+
+    platform: debian
+    edition: ce
+    version: 2020.2.1
+
+    features:
+      - call
+      - register
+      - rtcp
+
+    grafana:
+      datasources:
+        database: sip3

--- a/examples/sip3-hoof.yml
+++ b/examples/sip3-hoof.yml
@@ -1,0 +1,17 @@
+all:
+  hosts:
+    hoof:
+      ansible_host: 192.168.215.15
+  vars:
+    ansible_user: ansible
+    ansible_port: 22
+    ansible_become: true
+
+    platform: debian
+    edition: ce
+    version: 2020.2.1
+
+    features:
+      - call
+      - register
+      - rtcp

--- a/examples/sip3-influxdb.yml
+++ b/examples/sip3-influxdb.yml
@@ -1,0 +1,24 @@
+all:
+  hosts:
+    influxdb:
+      ansible_host: 192.168.215.15
+  vars:
+    ansible_user: ansible
+    ansible_port: 22
+    ansible_become: true
+
+    platform: debian
+    edition: ce
+    version: 2020.2.1
+
+    features:
+      - call
+      - register
+      - rtcp
+
+    influxdb:
+      # If you want to use for InfluxDB exclusive ip address, you can set here. Otherwise will be use variable 'address'
+      address: 127.0.0.1
+      port: 8086
+      path: /var/lib/influxdb
+      db: sip3

--- a/examples/sip3-mongodb.yml
+++ b/examples/sip3-mongodb.yml
@@ -1,0 +1,25 @@
+all:
+  hosts:
+    mongodb:
+      ansible_host: 192.168.215.15
+  vars:
+    ansible_user: ansible
+    ansible_port: 22
+    ansible_become: true
+
+    platform: debian
+    edition: ce
+    version: 2020.2.1
+
+    features:
+      - call
+      - register
+      - rtcp
+
+    mongodb:
+      version: 4.4
+      # If you want to use for MongoDB exclusive ip address, you can set here. Otherwise will be use variable 'address'
+      address: 127.0.0.1
+      port: 27017
+      path: /var/lib/mongodb
+      db: sip3

--- a/examples/sip3-salto.yml
+++ b/examples/sip3-salto.yml
@@ -1,0 +1,23 @@
+all:
+  hosts:
+    salto:
+      ansible_host: 192.168.215.15
+  vars:
+    ansible_user: ansible
+    ansible_port: 22
+    ansible_become: true
+
+    platform: debian
+    edition: ce
+    version: 2020.2.1
+
+    features:
+      - call
+      - register
+      - rtcp
+
+    salto:
+      server:
+        uri: udp://0.0.0.0:15060
+      management:
+        uri: udp://0.0.0.0:15090

--- a/examples/sip3-twig.yml
+++ b/examples/sip3-twig.yml
@@ -1,0 +1,17 @@
+all:
+  hosts:
+    twig:
+      ansible_host: 192.168.215.15
+  vars:
+    ansible_user: ansible
+    ansible_port: 22
+    ansible_become: true
+
+    platform: debian
+    edition: ce
+    version: 2020.2.1
+
+    features:
+      - call
+      - register
+      - rtcp

--- a/inventories/inventory.yml
+++ b/inventories/inventory.yml
@@ -53,6 +53,8 @@ all:
     ansible_user: root
     # Management ip address for SSH access
     ansible_host: 127.0.0.1
+    # May be usefull for Non-SSH connection in case of localhost (127.0.0.1). Uncomment for use.
+    # ansible_connection: local
     # SSH port for management access to hosts
     ansible_port: 22
     # Properties ansible_user, ansible_host and ansible_port can be individual for each hosts,

--- a/roles/captain/defaults/main.yml
+++ b/roles/captain/defaults/main.yml
@@ -1,5 +1,5 @@
 state: started
-add_system_repo: yes
+add_system_repo: true
 edition: ce
 features:
   - call

--- a/roles/captain/tasks/debian.yml
+++ b/roles/captain/tasks/debian.yml
@@ -1,5 +1,11 @@
 - name: "Installing"
   block:
+
+    - name: "Make sure we have a 'wheel' group"
+      group:
+        name: wheel
+        state: present
+
     - name: "Create SIP3 account"
       user:
         name: sip3
@@ -7,18 +13,15 @@
         groups: wheel
         append: yes
 
-    - name: "Add CentOS repository"
-      yum_repository:
-        name: centos-updates
-        description: "CentOS-$releasever - Updates"
-        mirrorlist: http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
-        gpgcheck: no
-        proxy: "{{ proxy | default('_none_') }}"
+    - name: "Add Debian repository"
+      apt_repository:
+        repo: deb http://deb.debian.org/debian/ {{ ansible_facts['lsb']['codename'] }} main contrib
+        state: present
       when: add_system_repo == true
 
     - name: "Install libpcap library"
-      yum:
-        name: libpcap
+      apt:
+        name: libpcap0.8
 
     - name: "Creates directories for SIP3 Captain"
       block:
@@ -42,6 +45,12 @@
           when: item.stat.exists == false
           with_items:
             - "{{ folder_stats.results }}"
+
+    - name: "Create /usr/lib/systemd/system directory if does not exists"
+      file:
+        path: "/usr/lib/systemd/system"
+        state: directory
+        mode: 0755
 
     - name: "Create SIP3 Captain application config"
       template:

--- a/roles/captain/tasks/main.yml
+++ b/roles/captain/tasks/main.yml
@@ -1,14 +1,18 @@
 - name: "Install Captain for CentOS"
   include: centos.yml
   when:
-    - platform == "centos"
+    - platform | lower == "centos"
+    - ansible_facts['distribution'] | lower == "centos"
+
+- name: "Install Captain for Debian"
+  include: debian.yml
+  when:
+    - platform | lower == "debian"
+    - ansible_facts['distribution'] | lower == "debian"
+    - ansible_facts['distribution_major_version'] | int >= 9
 
 #- name: "Install Captain for Docker"
 #  include: docker.yml
 #  when:
 #    - platform == "docker"
 #
-#- name: "Install Captain for Debian"
-#  include: debian.yml
-#  when:
-#    - platform == "debian"

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -1,1 +1,2 @@
 state: started
+add_system_repo: false

--- a/roles/grafana/tasks/debian.yml
+++ b/roles/grafana/tasks/debian.yml
@@ -1,0 +1,103 @@
+- name: "Installing"
+  block:
+    - name: "Add Debian repository"
+      apt_repository:
+        repo: deb http://deb.debian.org/debian/ {{ ansible_facts['lsb']['codename'] }} main contrib
+        state: present
+      when: add_system_repo == true
+
+    - name: "Install gnupg and apt-transport-https ... packages"
+      apt:
+        pkg:
+          - gnupg
+          - apt-transport-https
+          - software-properties-common
+
+    - name: "Add signing key for Grafana repository"
+      apt_key:
+        url: "https://packages.grafana.com/gpg.key"
+        state: present
+
+    - name: "Add Grafana repository"
+      apt_repository:
+        repo: deb https://packages.grafana.com/oss/deb stable main
+        state: present
+        filename: grafana
+
+    - name: "Install Grafana"
+      apt:
+        pkg:
+          - grafana
+
+    - name: "Create Grafana Datasource for SIP3 application"
+      template:
+        src: templates/sip3-datasource.yml.j2
+        dest: /etc/grafana/provisioning/datasources/sip3-datasource.yml
+
+    - name: "Create Grafana Dashboard for SIP3 application"
+      template:
+        src: templates/sip3-dashboard.yml.j2
+        dest: /etc/grafana/provisioning/dashboards/sip3-dashboard.yml
+
+    - name: "Copy Technical Dashboard to Grafana"
+      template:
+        src: templates/sip3-technical_dashboard.json.j2
+        dest: /etc/grafana/provisioning/dashboards/sip3-technical_dashboard.json
+
+    - name: "Create Grafana config for SIP3 application"
+      template:
+        src: templates/grafana.ini.j2
+        dest: /etc/grafana/grafana.ini
+
+    - name: "Start Grafana"
+      systemd:
+        name: grafana-server
+        daemon_reload: yes
+        state: restarted
+        enabled: yes
+  when: state == "started"
+
+- name: "Uninstalling"
+  block:
+    - name: "Stop Grafana"
+      systemd:
+        name: grafana-server
+        enabled: no
+        state: stopped
+
+    - name: "Uninstall Grafana"
+      apt:
+        pkg:
+          - grafana
+        autoremove: yes
+        state: absent
+
+    - name: "Purge project files"
+      block:
+        - name: "Checking project files"
+          stat:
+            path: "{{item}}"
+          register: folder_stats
+          with_items:
+            - "/etc/grafana/provisioning/datasources/sip3-datasource.yml"
+            - "/etc/grafana/provisioning/dashboards/sip3-technical_dashboard.json"
+            - "/etc/grafana/provisioning/dashboards/sip3-dashboard.yml"
+            - "/etc/yum.repos.d/grafana.repo"
+        - name: "Delete project files"
+          file:
+            path: "{{ item.item }}"
+            force: true
+            state: absent
+          when: item.stat.exists == true and item.stat.isdir == false
+          with_items:
+            - "{{folder_stats.results}}"
+        - name: "Delete project folders"
+          file:
+            path: "{{ item.item }}"
+            force: true
+            state: absent
+          when: item.stat.exists == true and item.stat.isdir == true
+          with_items:
+            - "{{folder_stats.results}}"
+      ignore_errors: yes
+  when: state == "absent"

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -1,14 +1,18 @@
-- name: "Install Hoof for CentOS"
+- name: "Install Grafana for CentOS"
   include: centos.yml
   when:
-    - platform == "centos"
+    - platform | lower == "centos"
+    - ansible_facts['distribution'] | lower == "centos"
 
-#- name: "Install Hoof for Docker"
+- name: "Install Grafana for Debian"
+  include: debian.yml
+  when:
+    - platform | lower == "debian"
+    - ansible_facts['distribution'] | lower == "debian"
+    - ansible_facts['distribution_major_version'] | int >= 9
+
+#- name: "Install Grafana for Docker"
 #  include: docker.yml
 #  when:
 #    - platform == "docker"
 #
-#- name: "Install Hoof for Debian"
-#  include: debian.yml
-#  when:
-#    - platform == "debian"

--- a/roles/hoof/defaults/main.yml
+++ b/roles/hoof/defaults/main.yml
@@ -1,5 +1,5 @@
 state: started
-add_system_repo: no
+add_system_repo: false
 hoof:
-  reconfigure: yes
+  reconfigure: true
 edition: ce

--- a/roles/hoof/tasks/debian.yml
+++ b/roles/hoof/tasks/debian.yml
@@ -1,0 +1,190 @@
+- name: "Installing"
+  block:
+    - name: "Add Debian repository"
+      apt_repository:
+        repo: deb http://deb.debian.org/debian/ {{ ansible_facts['lsb']['codename'] }} main contrib
+        state: present
+      when: add_system_repo == true
+
+    - name: "Install gnupg and apt-transport-https packages"
+      apt:
+        pkg:
+          - gnupg
+          - apt-transport-https
+
+    - name: "Add signing key for NGINX repository"
+      apt_key:
+        url: "https://nginx.org/keys/nginx_signing.key"
+        state: present
+
+    - name: "Add NGINX repository"
+      apt_repository:
+        repo: deb http://nginx.org/packages/debian {{ ansible_facts['lsb']['codename'] }} nginx
+        state: present
+        filename: nginx
+
+    - name: "Check and install tar and unzip"
+      apt:
+        pkg:
+          - tar
+          - unzip
+
+    - name: "Install NGINX"
+      apt:
+        pkg:
+          - nginx
+
+    - name: "Creates directories for SIP3 Hoof"
+      block:
+        - name: "Checking folders"
+          stat:
+            path: "{{item}}"
+          register: folder_stats
+          with_items:
+            - ["/etc/nginx/conf.d","/var/www/sip3-hoof"]
+        - name: "Creating multiple folders without disturbing previous permissions"
+          file:
+            path: "{{item.item}}"
+            state: directory
+            mode: 0755
+          when: item.stat.exists == false
+          with_items:
+            - "{{folder_stats.results}}"
+
+    - name: "Create NGINX config for SIP3 Hoof application"
+      template:
+        src: templates/sip3-hoof.conf.j2
+        dest: /etc/nginx/conf.d/sip3-hoof.conf
+
+    - name: "Reconfigure default NGINX config"
+      template:
+        src: templates/nginx.conf.j2
+        dest: /etc/nginx/nginx.conf
+      when: hoof.reconfigure == true
+
+    - name: "Download SIP3 Hoof via proxy version: {{ version | default('latest') }}"
+      block:
+        - name: "Download application via proxy into /var/www/sip3-hoof version: {{ version | default('latest') }}"
+          get_url:
+            url: https://maven.sip3.io/releases-ce/io/sip3/hoof/ce/sip3-hoof-ce/{{ version | default('latest') }}/sip3-hoof-ce-{{ version | default('latest') }}.tgz
+            dest: /var/www/sip3-hoof/sip3-hoof-ce.tgz
+            use_proxy: yes
+          environment:
+            https_proxy: "{{ proxy }}"
+
+        - name: "Extract SIP3 Hoof archive"
+          shell:
+            cmd: tar -zxvf sip3-hoof-ce.tgz && rm -f sip3-hoof-ce.tgz
+            chdir: /var/www/sip3-hoof/
+            warn: no
+      when:
+        - proxy is defined
+        - edition == "ce"
+
+    - name: "Download SIP3 Hoof version: {{ version | default('latest') }}"
+      block:
+        - name: "Download application into /var/www/sip3-hoof version: {{ version | default('latest') }}"
+          get_url:
+            url: https://maven.sip3.io/releases-ce/io/sip3/hoof/ce/sip3-hoof-ce/{{ version | default('latest') }}/sip3-hoof-ce-{{ version | default('latest') }}.tgz
+            dest: /var/www/sip3-hoof/sip3-hoof-ce.tgz
+            use_proxy: no
+
+        - name: "Extract SIP3 Hoof archive"
+          shell:
+            cmd: tar -zxvf sip3-hoof-ce.tgz && rm -f sip3-hoof-ce.tgz
+            chdir: /var/www/sip3-hoof/
+            warn: no
+      when:
+        - proxy is undefined
+        - edition == "ce"
+
+    - name: "Download SIP3 Hoof EE via proxy version: {{ version | default('latest') }}"
+      block:
+        - name: "Download application via proxy into /var/www/sip3-hoof version: {{ version | default('latest') }}"
+          get_url:
+            url: https://maven.sip3.io/releases-ee/io/sip3/hoof/{{ edition }}/sip3-hoof-{{ edition }}/{{ version | default('latest') }}/sip3-hoof-{{ edition }}-{{ version | default('latest') }}.tgz
+            dest: /var/www/sip3-hoof/sip3-hoof-{{ edition }}.tgz
+            url_username: "{{ support.username | default('none') }}"
+            url_password: "{{ support.password | default('none') }}"
+            use_proxy: yes
+          environment:
+            https_proxy: "{{ proxy }}"
+
+        - name: "Extract SIP3 Hoof EE archive"
+          shell:
+            cmd: tar -zxvf sip3-hoof-{{ edition }}.tgz && rm -f sip3-hoof-{{ edition }}.tgz
+            chdir: /var/www/sip3-hoof/
+            warn: no
+      when:
+        - proxy is defined
+        - edition != "ce"
+
+    - name: "Download SIP3 Hoof EE version: {{ version | default('latest') }}"
+      block:
+        - name: "Download application into /var/www/sip3-hoof version: {{ version | default('latest') }}"
+          get_url:
+            url: https://maven.sip3.io/releases-ee/io/sip3/hoof/{{ edition }}/sip3-hoof-{{ edition }}/{{ version | default('latest') }}/sip3-hoof-{{ edition }}-{{ version | default('latest') }}.tgz
+            dest: /var/www/sip3-hoof/sip3-hoof-{{ edition }}.tgz
+            url_username: "{{ support.username | default('none') }}"
+            url_password: "{{ support.password | default('none') }}"
+            use_proxy: no
+
+        - name: "Extract SIP3 Hoof EE archive"
+          shell:
+            cmd: tar -zxvf sip3-hoof-{{ edition }}.tgz && rm -f sip3-hoof-{{ edition }}.tgz
+            chdir: /var/www/sip3-hoof/
+            warn: no
+      when:
+        - proxy is undefined
+        - edition != "ce"
+
+    - name: "Start NGINX"
+      systemd:
+        name: nginx
+        state: started
+        daemon_reload: yes
+        enabled: yes
+  when: state == "started"
+
+- name: "Uninstalling"
+  block:
+    - name: "Stop NGINX"
+      systemd:
+        name: nginx
+        state: stopped
+        enabled: no
+
+    - name: "Uninstall NGINX"
+      apt:
+        pkg:
+          - nginx
+        autoremove: yes
+        state: absent
+
+    - name: "Purge project files"
+      block:
+        - name: "Checking project files"
+          stat:
+            path: "{{item}}"
+          register: folder_stats
+          with_items:
+            - "/etc/yum.repos.d/nginx.repo"
+            - "/var/www/sip3-hoof"
+        - name: "Delete project files"
+          file:
+            path: "{{ item.item }}"
+            force: true
+            state: absent
+          when: item.stat.exists == true and item.stat.isdir == false
+          with_items:
+            - "{{folder_stats.results}}"
+        - name: "Delete project folders"
+          file:
+            path: "{{ item.item }}"
+            force: true
+            state: absent
+          when: item.stat.exists == true and item.stat.isdir == true
+          with_items:
+            - "{{folder_stats.results}}"
+      ignore_errors: yes
+  when: state == "absent"

--- a/roles/hoof/tasks/main.yml
+++ b/roles/hoof/tasks/main.yml
@@ -1,14 +1,18 @@
 - name: "Install Hoof for CentOS"
   include: centos.yml
   when:
-    - platform == "centos"
+    - platform | lower == "centos"
+    - ansible_facts['distribution'] | lower == "centos"
+
+- name: "Install Hoof for Debian"
+  include: debian.yml
+  when:
+    - platform | lower == "debian"
+    - ansible_facts['distribution'] | lower == "debian"
+    - ansible_facts['distribution_major_version'] | int >= 9
 
 #- name: "Install Hoof for Docker"
 #  include: docker.yml
 #  when:
 #    - platform == "docker"
 #
-#- name: "Install Hoof for Debian"
-#  include: debian.yml
-#  when:
-#    - platform == "debian"

--- a/roles/influxdb/defaults/main.yml
+++ b/roles/influxdb/defaults/main.yml
@@ -1,1 +1,2 @@
 state: started
+add_system_repo: false

--- a/roles/influxdb/tasks/debian.yml
+++ b/roles/influxdb/tasks/debian.yml
@@ -1,0 +1,93 @@
+- name: "Installing"
+  block:
+    - name: "Add Debian repository"
+      apt_repository:
+        repo: deb http://deb.debian.org/debian/ {{ ansible_facts['lsb']['codename'] }} main contrib
+        state: present
+      when: add_system_repo == true
+
+    - name: "Install gnupg and apt-transport-https packages"
+      apt:
+        pkg:
+          - gnupg
+          - apt-transport-https
+
+    - name: "Add signing key for InfluxDB repository"
+      apt_key:
+        url: "https://repos.influxdata.com/influxdb.key"
+        state: present
+
+    - name: "Add InfluxDB repository"
+      apt_repository:
+        repo: deb https://repos.influxdata.com/debian {{ ansible_facts['lsb']['codename'] }} stable
+        state: present
+        filename: influxdb
+
+    - name: "Install the latest version of InfluxDB"
+      apt:
+        pkg:
+          - influxdb
+
+    - name: "Creates directory {{ influxdb.path | default('/var/lib/influxdb') }} for InfluxDB"
+      file:
+        path: "{{ influxdb.path | default('/var/lib/influxdb') }}"
+        state: directory
+        mode: 0755
+        group: influxdb
+        owner: influxdb
+
+    - name: "Create InfluxDB config"
+      template:
+        src: templates/influxdb.conf.j2
+        dest: /etc/influxdb/influxdb.conf
+
+    - name: "Start service InfluxDB"
+      systemd:
+        name: influxdb
+        state: started
+        daemon_reload: yes
+        enabled: yes
+  when: state == "started"
+
+- name: "Uninstalling"
+  block:
+    - name: Stop InfluxDB
+      systemd:
+        name: influxdb
+        state: stopped
+        enabled: no
+
+    - name: "Uninstall InfluxDB"
+      yum:
+        name: influxdb
+        autoremove: yes
+        state: absent
+
+    - name: "Purge project files"
+      block:
+        - name: "Collecting project files"
+          stat:
+            path: "{{item}}"
+          register: folder_stats
+          with_items:
+            - "/etc/influxdb"
+            - "{{ influxdb.path | default('/var/lib/influxdb') }}"
+            - "/etc/yum.repos.d/influxdb.repo"
+        - name: "Delete project files"
+          file:
+            path: "{{ item.item }}"
+            force: true
+            state: absent
+          when: item.stat.exists == true and item.stat.isdir == false
+          with_items:
+            - "{{folder_stats.results}}"
+        - name: "Delete project folders"
+          file:
+            path: "{{ item.item }}"
+            force: true
+            state: absent
+          when: item.stat.exists == true and item.stat.isdir == true
+          with_items:
+            - "{{folder_stats.results}}"
+      ignore_errors: yes
+  when: state == "absent"

--- a/roles/influxdb/tasks/main.yml
+++ b/roles/influxdb/tasks/main.yml
@@ -1,14 +1,18 @@
 - name: "Install Statistics Storage for CentOS"
   include: centos.yml
   when:
-    - platform == "centos"
+    - platform | lower == "centos"
+    - ansible_facts['distribution'] | lower == "centos"
+
+- name: "Install Statistics Storage for Debian"
+  include: debian.yml
+  when:
+    - platform | lower == "debian"
+    - ansible_facts['distribution'] | lower == "debian"
+    - ansible_facts['distribution_major_version'] | int >= 9
 
 #- name: "Install Statistics Storage for Docker"
 #  include: docker.yml
 #  when:
 #    - platform == "docker"
 #
-#- name: "Install Statistics Storage for Debian"
-#  include: debian.yml
-#  when:
-#    - platform == "debian"

--- a/roles/java/defaults/main.yml
+++ b/roles/java/defaults/main.yml
@@ -1,4 +1,4 @@
 state: started
-add_system_repo: yes
+add_system_repo: false
 java:
   version: 1.8.0

--- a/roles/java/tasks/centos.yml
+++ b/roles/java/tasks/centos.yml
@@ -7,11 +7,11 @@
         mirrorlist: http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=updates&infra=$infra
         gpgcheck: no
         proxy: "{{ proxy | default('_none_') }}"
-      when: add_system_repo == "yes"
+      when: add_system_repo == true
 
-    - name: "Install the {{ java.version }} version of OpenJDK"
+    - name: "Install the {{ java.version.centos }} version of OpenJDK"
       yum:
-        name: java-{{ java.version }}-openjdk
+        name: java-{{ java.version.centos }}-openjdk
   when: state == "started"
 
 #

--- a/roles/java/tasks/debian.yml
+++ b/roles/java/tasks/debian.yml
@@ -1,0 +1,29 @@
+- name: "Installing"
+  block:
+    - name: "Add Debian repository"
+      apt_repository:
+        repo: deb http://deb.debian.org/debian/ {{ ansible_facts['lsb']['codename'] }} main contrib
+        state: present
+      when: add_system_repo == true
+
+    - name: "Install the default version of OpenJDK from Debian repository"
+      apt:
+        name: default-jre
+
+  when: state == "started"
+
+#
+#- name: "Uninstalling"
+#  block:
+#    - name: "Uninstall Java"
+#      apt:
+#        pkg: default-jre
+#        autoremove: yes
+#        state: absent
+#    - name: "Delete Debian repository"
+#      file:
+#        path: /etc/apt/sources.list.d/deb_debian_org_debian.list
+#        force: true
+#        state: absent
+#      when: add_system_repo is defined
+#  when: state == "absent"

--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -1,14 +1,18 @@
 - name: "Install Java for CentOS"
   include: centos.yml
   when:
-    - platform == "centos"
+    - platform | lower == "centos"
+    - ansible_facts['distribution'] | lower == "centos"
 
-#- name: "Install Storage for Docker"
+- name: "Install Java for Debian"
+  include: debian.yml
+  when:
+    - platform | lower == "debian"
+    - ansible_facts['distribution'] | lower == "debian"
+    - ansible_facts['distribution_major_version'] | int >= 9
+
+#- name: "Install Java for Docker"
 #  include: docker.yml
 #  when:
 #    - platform == "docker"
 #
-#- name: "Install Storage for Debian"
-#  include: debian.yml
-#  when:
-#    - platform == "debian"

--- a/roles/mongodb/defaults/main.yml
+++ b/roles/mongodb/defaults/main.yml
@@ -1,4 +1,5 @@
 state: started
+add_system_repo: true
 hostmap:
   - name: "node-1"
     sip:

--- a/roles/mongodb/tasks/debian.yml
+++ b/roles/mongodb/tasks/debian.yml
@@ -1,0 +1,126 @@
+- name: "Installing"
+  block:
+
+    - name: "Add Debian repository"
+      apt_repository:
+        repo: deb http://deb.debian.org/debian/ {{ ansible_facts['lsb']['codename'] }} main contrib
+        state: present
+      when: add_system_repo == true
+
+    - name: "Install gnupg package"
+      apt:
+        name: "gnupg"
+
+    - name: "Add signing key for Mongo repository"
+      apt_key:
+        url: "https://www.mongodb.org/static/pgp/server-{{ mongodb.version }}.asc"
+        state: present
+
+    - name: "Add MongoDB repository"
+      apt_repository:
+        repo: deb http://repo.mongodb.org/apt/debian {{ ansible_facts['lsb']['codename'] }}/mongodb-org/{{ mongodb.version }} main
+        state: present
+        filename: mongodb-org-{{ mongodb.version }}
+
+    - name: "Install the latest version of MongoDB"
+      apt:
+        pkg:
+          - mongodb-org-server
+          - mongodb-org-shell
+
+    - name: "Creates directory {{ mongodb.path | default('/data/db') }} for MongoDB"
+      file:
+        path: "{{ mongodb.path | default('/data/db') }}"
+        state: directory
+        mode: 0755
+        group: mongodb
+        owner: mongodb
+
+    - name: "Create directory '/var/run/mongodb' for MongoDB"
+      file:
+        path: "/var/run/mongodb"
+        state: directory
+        mode: 0755
+        group: mongodb
+        owner: mongodb
+
+    - name: "Create MongoDB config"
+      template:
+        src: templates/mongod.conf.j2
+        dest: /etc/mongod.conf
+
+    - name: "Deploying MongoDB config for recreate /var/run/mongodb on tmpfs"
+      template:
+        src: templates/mongodb.conf.tmpfs.j2
+        dest: /usr/lib/tmpfiles.d/mongodb.conf
+
+    - name: "Start service MongoDB"
+      systemd:
+        name: mongod
+        daemon_reload: yes
+        enabled: yes
+        state: restarted
+
+    - name: "Wait for MongoDB service starts"
+      wait_for:
+        host: 127.0.0.1
+        port: "{{ mongodb.port }}"
+        delay: 1
+        timeout: 15
+
+    - name: "Flush hostmap"
+      shell: mongo --host "{{ mongodb.address | default(address | default('127.0.0.1')) }}" "{{ mongodb.db | default(address | default('sip3')) }}" --port {{ mongodb.port | default('27017') }} --eval 'db.hosts.drop()'
+
+    - name: "Insert hostmap into MongoDB"
+      shell: mongo --host "{{ mongodb.address | default(address | default('127.0.0.1')) }}" "{{ mongodb.db | default(address | default('sip3')) }}" --port {{ mongodb.port | default('27017') }} --eval 'db.hosts.insert({{ item | to_json(ensure_ascii=False)}})'
+      loop: "{{ hostmap }}"
+
+    - name: "Create index for hostmap"
+      shell: "mongo --host \"{{ mongodb.address | default(address | default('127.0.0.1')) }}\" \"{{ mongodb.db | default(address | default('sip3')) }}\" --port {{ mongodb.port | default('27017') }} --eval 'db.hosts.createIndex({ name: 1 })'"
+  when: state == "started"
+
+- name: "Uninstalling"
+  block:
+    - name: "Stop MongoDB"
+      systemd:
+        name: mongod
+        state: stopped
+        enabled: no
+
+    - name: "Uninstall MongoDB"
+      apt:
+        pkg:
+          - mongodb-org-server
+          - mongodb-org-shell
+        autoremove: yes
+        state: absent
+
+    - name: "Purge project files"
+      block:
+        - name: "Collecting project files"
+          stat:
+            path: "{{item}}"
+          register: folder_stats
+          with_items:
+            - "/etc/mongod.conf"
+            - "{{ mongodb.path | default('/data/db') }}/"
+            - "/var/log/mongodb"
+            - "/etc/yum.repos.d/mongodb-org-{{ mongodb.version }}.repo"
+        - name: "Delete project files"
+          file:
+            path: "{{ item.item }}"
+            force: true
+            state: absent
+          when: item.stat.exists == true and item.stat.isdir == false
+          with_items:
+            - "{{folder_stats.results}}"
+        - name: "Delete project folders"
+          file:
+            path: "{{ item.item }}"
+            force: true
+            state: absent
+          when: item.stat.exists == true and item.stat.isdir == true
+          with_items:
+            - "{{folder_stats.results}}"
+      ignore_errors: yes
+  when: state == "absent"

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -1,14 +1,18 @@
 - name: "Install Storage for CentOS"
   include: centos.yml
   when:
-    - platform == "centos"
+    - platform | lower == "centos"
+    - ansible_facts['distribution'] | lower == "centos"
+
+- name: "Install Storage for Debian"
+  include: debian.yml
+  when:
+    - platform | lower == "debian"
+    - ansible_facts['distribution'] | lower == "debian"
+    - ansible_facts['distribution_major_version'] | int >= 9
 
 #- name: "Install Storage for Docker"
 #  include: docker.yml
 #  when:
 #    - platform == "docker"
 #
-#- name: "Install Storage for Debian"
-#  include: debian.yml
-#  when:
-#    - platform == "debian"

--- a/roles/mongodb/templates/mongodb.conf.tmpfs.j2
+++ b/roles/mongodb/templates/mongodb.conf.tmpfs.j2
@@ -1,0 +1,1 @@
+d /var/run/mongodb 0755 mongodb mongodb

--- a/roles/salto/tasks/debian.yml
+++ b/roles/salto/tasks/debian.yml
@@ -1,0 +1,182 @@
+- name: "Installing"
+  block:
+    - name: "Create SIP3 account"
+      user:
+        name: sip3
+        comment: "SIP3 Account"
+        append: yes
+
+    - name: "Creates directories for SIP3 Salto"
+      block:
+        - name: "Checking folders"
+          stat:
+            path: "{{ item }}"
+          register: folder_stats
+          with_items:
+            - "/etc/sip3-salto"
+            - "/var/log/sip3-salto"
+            - "/opt/sip3-salto"
+            - "/opt/sip3-salto/udf"
+            - "/tmp/sip3-salto"
+        - name: "Creating multiple folders without disturbing previous permissions"
+          file:
+            path: "{{ item.item }}"
+            state: directory
+            mode: 0755
+            group: sip3
+            owner: sip3
+          when: item.stat.exists == false
+          with_items:
+            - "{{ folder_stats.results }}"
+
+    - name: "Create /usr/lib/systemd/system directory if does not exists"
+      file:
+        path: "/usr/lib/systemd/system"
+        state: directory
+        mode: 0755
+
+    - name: "Create SIP3 Salto application config"
+      template:
+        src: templates/application.yml.j2
+        dest: /etc/sip3-salto/application.yml
+
+    - name: "Create SIP3 Salto application log config"
+      template:
+        src: templates/logback.xml.j2
+        dest: /etc/sip3-salto/logback.xml
+
+    - name: "Create SIP3 Salto start script"
+      template:
+        src: templates/sip3-salto.j2
+        dest: /opt/sip3-salto/sip3-salto
+        mode: 0755
+
+    - name: "Create SIP3 Salto environment config file"
+      template:
+        src: templates/environment.conf.j2
+        dest: /etc/sip3-salto/environment.conf
+
+    - name: "Create SIP3 Salto application codecs config"
+      template:
+        src: templates/codecs.yml.j2
+        dest: /etc/sip3-salto/codecs.yml
+
+    - name: "Create Vert.x metrics config"
+      template:
+        src: templates/vertx-options.json.j2
+        dest: /etc/sip3-salto/vertx-options.json
+      when: '"vertx_metrics" in features'
+
+    - name: "Create SIP3 Salto UDF functions"
+      copy:
+        content: "{{ item.body }}"
+        dest: /opt/sip3-salto/udf/{{ item.name }}
+      loop: "{{ salto.udf }}"
+      when:
+        - '"udf" in features'
+        - salto.udf is defined
+
+    - name: "Create SIP3 Salto UDF function template"
+      template:
+        src: templates/sip3_message_udf.groovy.j2
+        dest: /opt/sip3-salto/udf/sip3_udf_message.groovy
+      when:
+        - '"udf" in features'
+        - salto.udf is undefined
+
+    - name: "Create SIP3 Salto systemd service"
+      template:
+        src: templates/sip3-salto.service.j2
+        dest: /usr/lib/systemd/system/sip3-salto.service
+
+    - name: "Get SIP3 Salto application via proxy version: {{ version | default('latest') }}"
+      get_url:
+        url: https://maven.sip3.io/releases-ce/io/sip3/salto/ce/sip3-salto-ce/{{ version | default('latest') }}/sip3-salto-ce-{{ version | default('latest') }}.jar
+        dest: /opt/sip3-salto/sip3-salto.jar
+        use_proxy: yes
+      environment:
+        https_proxy: "{{ proxy | default('_none_') }}"
+      when:
+        - proxy is defined
+        - edition == "ce"
+
+    - name: "Get SIP3 Salto application version: {{ version | default('latest') }}"
+      get_url:
+        url: https://maven.sip3.io/releases-ce/io/sip3/salto/ce/sip3-salto-ce/{{ version | default('latest') }}/sip3-salto-ce-{{ version | default('latest') }}.jar
+        dest: /opt/sip3-salto/sip3-salto.jar
+        use_proxy: no
+      when:
+        - proxy is undefined
+        - edition == "ce"
+
+    - name: "Get SIP3 Salto EE application via proxy version: {{ version | default('latest') }}"
+      get_url:
+        url: https://maven.sip3.io/releases-ee/io/sip3/salto/{{ edition }}/sip3-salto-{{ edition }}/{{ version | default('latest') }}/sip3-salto-{{ edition }}-{{ version | default('latest') }}.jar
+        dest: /opt/sip3-salto/sip3-salto.jar
+        use_proxy: yes
+        url_username: "{{ support.username | default('none') }}"
+        url_password: "{{ support.password | default('none') }}"
+      environment:
+        https_proxy: "{{ proxy }}"
+      when:
+        - proxy is defined
+        - edition != "ce"
+
+    - name: "Get SIP3 Salto EE application version: {{ version | default('latest') }}"
+      get_url:
+        url: https://maven.sip3.io/releases-ee/io/sip3/salto/{{ edition }}/sip3-salto-{{ edition }}/{{ version | default('latest') }}/sip3-salto-{{ edition }}-{{ version | default('latest') }}.jar
+        dest: /opt/sip3-salto/sip3-salto.jar
+        use_proxy: no
+        url_username: "{{ support.username | default('none') }}"
+        url_password: "{{ support.password | default('none') }}"
+      when:
+        - proxy is undefined
+        - edition != "ce"
+
+    - name: "Start SIP3 Salto"
+      systemd:
+        name: sip3-salto
+        daemon_reload: yes
+        state: restarted
+        enabled: yes
+  when: state == "started"
+
+- name: "Uninstalling"
+  block:
+    - name: "Stop SIP3 Salto"
+      systemd:
+        name: sip3-salto
+        enabled: no
+        state: stopped
+
+    - name: "Purge project files"
+      block:
+        - name: "Collecting project files"
+          stat:
+            path: "{{item}}"
+          register: folder_stats
+          with_items:
+            - "/etc/sip3-salto"
+            - "/var/log/sip3-salto"
+            - "/opt/sip3-salto/udf"
+            - "/opt/sip3-salto"
+            - "/tmp/sip3-salto"
+            - "/usr/lib/systemd/system/sip3-salto.service"
+        - name: "Delete project files"
+          file:
+            path: "{{ item.item }}"
+            force: true
+            state: absent
+          when: item.stat.exists == true and item.stat.isdir == false
+          with_items:
+            - "{{folder_stats.results}}"
+        - name: "Delete project folders"
+          file:
+            path: "{{ item.item }}"
+            force: true
+            state: absent
+          when: item.stat.exists == true and item.stat.isdir == true
+          with_items:
+            - "{{folder_stats.results}}"
+      ignore_errors: yes
+  when: state == "absent"

--- a/roles/salto/tasks/main.yml
+++ b/roles/salto/tasks/main.yml
@@ -1,14 +1,18 @@
 - name: "Install Salto for CentOS"
   include: centos.yml
   when:
-    - platform == "centos"
+    - platform | lower == "centos"
+    - ansible_facts['distribution'] | lower == "centos"
+
+- name: "Install Salto for Debian"
+  include: debian.yml
+  when:
+    - platform | lower == "debian"
+    - ansible_facts['distribution'] | lower == "debian"
+    - ansible_facts['distribution_major_version'] | int >= 9
 
 #- name: "Install Salto for Docker"
 #  include: docker.yml
 #  when:
 #    - platform == "docker"
 #
-#- name: "Install Salto for Debian"
-#  include: debian.yml
-#  when:
-#    - platform == "debian"

--- a/roles/twig/tasks/debian.yml
+++ b/roles/twig/tasks/debian.yml
@@ -1,0 +1,152 @@
+- name: "Installing"
+  block:
+    - name: "Create SIP3 account"
+      user:
+        name: sip3
+        comment: "SIP3 Account"
+        append: yes
+
+    - name: "Creates directories for SIP3 Twig"
+      block:
+        - name: "Checking folders"
+          stat:
+            path: "{{item}}"
+          register: folder_stats
+          with_items:
+            - "/etc/sip3-twig"
+            - "/var/log/sip3-twig"
+            - "/opt/sip3-twig"
+            - "/tmp/sip3-twig"
+        - name: "Creating multiple folders without disturbing previous permissions"
+          file:
+            path: "{{item.item}}"
+            state: directory
+            mode: 0755
+            group: sip3
+            owner: sip3
+          when: item.stat.exists == false
+          with_items:
+            - "{{ folder_stats.results }}"
+
+    - name: "Create /usr/lib/systemd/system directory if does not exists"
+      file:
+        path: "/usr/lib/systemd/system"
+        state: directory
+        mode: 0755
+
+    - name: "Create SIP3 Twig application config"
+      template:
+        src: templates/application.yml.j2
+        dest: /etc/sip3-twig/application.yml
+
+    - name: "Create SIP3 Twig application log config"
+      template:
+        src: templates/logback.xml.j2
+        dest: /etc/sip3-twig/logback.xml
+
+    - name: "Create SIP3 Twig systemd service"
+      template:
+        src: templates/sip3-twig.service.j2
+        dest: /usr/lib/systemd/system/sip3-twig.service
+
+    - name: "Create SIP3 Twig start script"
+      template:
+        src: templates/sip3-twig.j2
+        dest: /opt/sip3-twig/sip3-twig
+        mode: 0755
+
+    - name: "Create SIP3 Twig environment config file"
+      template:
+        src: templates/environment.conf.j2
+        dest: /etc/sip3-twig/environment.conf
+
+    - name: "Get SIP3 Twig application via proxy version: {{ version | default('latest') }}"
+      get_url:
+        url: https://maven.sip3.io/releases-ce/io/sip3/twig/ce/sip3-twig-ce/{{ version | default('latest') }}/sip3-twig-ce-{{ version | default('latest') }}.jar
+        dest: /opt/sip3-twig/sip3-twig.jar
+        use_proxy: yes
+      environment:
+        https_proxy: "{{ proxy | default('_none_') }}"
+      when:
+        - proxy is defined
+        - edition == "ce"
+
+    - name: "Get SIP3 Twig application version: {{ version | default('latest') }}"
+      get_url:
+        url: https://maven.sip3.io/releases-ce/io/sip3/twig/ce/sip3-twig-ce/{{ version | default('latest') }}/sip3-twig-ce-{{ version | default('latest') }}.jar
+        dest: /opt/sip3-twig/sip3-twig.jar
+        use_proxy: no
+      when:
+        - proxy is undefined
+        - edition == "ce"
+
+    - name: "Get SIP3 Twig EE application via proxy version: {{ version | default('latest') }}"
+      get_url:
+        url: https://maven.sip3.io/releases-ee/io/sip3/twig/{{ edition }}/sip3-twig-{{ edition }}/{{ version | default('latest') }}/sip3-twig-{{ edition }}-{{ version | default('latest') }}.jar
+        dest: /opt/sip3-twig/sip3-twig.jar
+        use_proxy: yes
+        url_username: "{{ support.username | default('none') }}"
+        url_password: "{{ support.password | default('none') }}"
+      environment:
+        https_proxy: "{{ proxy }}"
+      when:
+        - proxy is defined
+        - edition != "ce"
+
+    - name: "Get SIP3 Twig EE application version: {{ version | default('latest') }}"
+      get_url:
+        url: https://maven.sip3.io/releases-ee/io/sip3/twig/{{ edition }}/sip3-twig-{{ edition }}/{{ version | default('latest') }}/sip3-twig-{{ edition }}-{{ version | default('latest') }}.jar
+        dest: /opt/sip3-twig/sip3-twig.jar
+        use_proxy: no
+        url_username: "{{ support.username | default('none') }}"
+        url_password: "{{ support.password | default('none') }}"
+      when:
+        - proxy is undefined
+        - edition != "ce"
+
+    - name: "Start SIP3 Twig"
+      systemd:
+        name: sip3-twig
+        daemon_reload: yes
+        state: restarted
+        enabled: yes
+  when: state == "started"
+
+- name: "Uninstalling"
+  block:
+    - name: Stop SIP3 Twig
+      systemd:
+        name: sip3-twig
+        enabled: no
+        state: stopped
+
+    - name: "Purge project files"
+      block:
+        - name: "Collecting project files"
+          stat:
+            path: "{{item}}"
+          register: folder_stats
+          with_items:
+            - "/etc/sip3-twig"
+            - "/var/log/sip3-twig"
+            - "/opt/sip3-twig"
+            - "/tmp/sip3-twig"
+            - "/usr/lib/systemd/system/sip3-twig.service"
+        - name: "Delete project files"
+          file:
+            path: "{{ item.item }}"
+            force: true
+            state: absent
+          when: item.stat.exists == true and item.stat.isdir == false
+          with_items:
+            - "{{folder_stats.results}}"
+        - name: "Delete project folders"
+          file:
+            path: "{{ item.item }}"
+            force: true
+            state: absent
+          when: item.stat.exists == true and item.stat.isdir == true
+          with_items:
+            - "{{folder_stats.results}}"
+      ignore_errors: yes
+  when: state == "absent"

--- a/roles/twig/tasks/main.yml
+++ b/roles/twig/tasks/main.yml
@@ -1,14 +1,18 @@
 - name: "Install Twig for CentOS"
   include: centos.yml
   when:
-    - platform == "centos"
+    - platform | lower == "centos"
+    - ansible_facts['distribution'] | lower == "centos"
+
+- name: "Install Twig for Debian"
+  include: debian.yml
+  when:
+    - platform | lower == "debian"
+    - ansible_facts['distribution'] | lower == "debian"
+    - ansible_facts['distribution_major_version'] | int >= 9
 
 #- name: "Install Twig for Docker"
 #  include: docker.yml
 #  when:
 #    - platform == "docker"
 #
-#- name: "Install Twig for Debian"
-#  include: debian.yml
-#  when:
-#    - platform == "debian"


### PR DESCRIPTION
* Added: debian distribution in all tasks, examples

* Added: debian.yml in all tasks

* Modified: main.yml in all tasks
Added: tasks for include debian
Modified:  additional check of distribution

* Modified: inventory.yml
Modified: 'java' dict expanded for include debian-repos versions of Java
Added: 'ansible_connection' parameter which may be usefull for local Non-SSH connections

* Modified: defaults variables in some tasks
Added: 'add_system_repo' variable for separated roles installations (grafana, influxdb, mongodb)
Modified: 'java' dict expanded for include debian-repos versions of Java (java)

* Modified: centos.yml in java task
Modofied: corrected java.version variable according to modified inventory.yml

* Added: examples
Added: examples for captain, backend and separated installation of all tasks included in backend

* Fixed: config for recreate /var/run/mongodb on tmpfs after Debian host restart

* Added: config template in mongodb task

* Modified: mongodb task for deploying config template

* Modified: now using true/false in roles defaults settings enstead "yes"/"no" for uniformity

Modified: now using deb.debian.org in debian tasks instead a geographically localazed mirror for backing by a CDN

Modified: in java debian task modified the way of choosing JRE package version - now it will be the default JRE package for current debian release

* Modified: changed back Java settings in inventory.yml